### PR TITLE
Translate pages that were displaying in English while the rest of the site defaults to Norwegian

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,15 +4,15 @@ import IconBadge from '@/components/IconBadge'
 import type { IconBadgeTone } from '@/components/IconBadge'
 
 export const metadata = {
-  title: 'About Hire2Skill',
-  description: 'Hire2Skill connects people with trusted local helpers across Norway. Learn about our mission, story, and values.',
+  title: 'Om Hire2Skill',
+  description: 'Hire2Skill kobler folk med pålitelige lokale hjelpere over hele Norge. Lær om vår misjon, historie og verdier.',
 }
 
 const STATS = [
-  { value: '10,000+', label: 'Tasks completed' },
-  { value: '2,500+', label: 'Verified helpers' },
-  { value: '50+', label: 'Cities in Norway' },
-  { value: '4.8 ★', label: 'Average rating' },
+  { value: '10 000+', label: 'Oppdrag fullført' },
+  { value: '2 500+', label: 'Verifiserte hjelpere' },
+  { value: '50+', label: 'Byer i Norge' },
+  { value: '4,8 ★', label: 'Gjennomsnittlig vurdering' },
 ]
 
 const VALUES: Array<{
@@ -26,29 +26,29 @@ const VALUES: Array<{
     Icon: ShieldCheck,
     iconColor: '#1D4ED8',
     tone: 'blue',
-    title: 'Trust first',
-    desc: 'Every helper is ID-verified before they can accept bookings. Ratings and reviews are real — posted only by people who completed a task.',
+    title: 'Trygghet først',
+    desc: 'Alle hjelpere er ID-verifisert før de kan akseptere bestillinger. Vurderinger og anmeldelser er ekte — postet bare av folk som har fullført et oppdrag.',
   },
   {
     Icon: Bolt,
     iconColor: '#D97706',
     tone: 'amber',
-    title: 'Fast and easy',
-    desc: 'Post a task in under two minutes. Get matched with available helpers the same day. No endless back-and-forth.',
+    title: 'Raskt og enkelt',
+    desc: 'Legg ut et oppdrag på under to minutter. Bli matchet med tilgjengelige hjelpere samme dag. Ingen endeløs frem og tilbake.',
   },
   {
     Icon: Handshake,
     iconColor: '#059669',
     tone: 'emerald',
-    title: 'Fair for everyone',
-    desc: 'Helpers keep the majority of what they earn. Posters pay transparent prices with no hidden fees.',
+    title: 'Rettferdig for alle',
+    desc: 'Hjelpere beholder mesteparten av det de tjener. Oppdragsgivere betaler transparente priser uten skjulte avgifter.',
   },
   {
     Icon: Globe2,
     iconColor: '#0891B2',
     tone: 'cyan',
-    title: 'Local, always',
-    desc: 'We only operate in Norway. Our helpers live in your city and understand your community.',
+    title: 'Lokalt, alltid',
+    desc: 'Vi opererer kun i Norge. Våre hjelpere bor i din by og forstår ditt lokalsamfunn.',
   },
 ]
 
@@ -60,11 +60,11 @@ export default function AboutPage() {
       <div className="text-white" style={{ background: 'linear-gradient(135deg,#1E3A8A,#38BDF8)' }}>
         <div className="mx-auto max-w-4xl px-6 py-20 text-center">
           <h1 className="text-4xl sm:text-5xl font-extrabold mb-5 leading-tight">
-            Norway&apos;s trusted platform<br />for local help
+            Norges pålitelige plattform<br />for lokal hjelp
           </h1>
           <p className="text-lg opacity-90 max-w-2xl mx-auto">
-            Hire2Skill makes it easy to find skilled, verified helpers for any task — from cleaning and moving
-            to tutoring and tech support. We&apos;re building a more connected Norway, one task at a time.
+            Hire2Skill gjør det enkelt å finne dyktige, verifiserte hjelpere for alle typer oppdrag — fra rengjøring og flytting
+            til undervisning og teknisk støtte. Vi bygger et mer sammenknyttet Norge, ett oppdrag av gangen.
           </p>
         </div>
       </div>
@@ -83,23 +83,23 @@ export default function AboutPage() {
 
       {/* Story */}
       <div className="mx-auto max-w-3xl px-6 py-16">
-        <h2 className="text-2xl font-extrabold text-gray-900 mb-5">Our story</h2>
+        <h2 className="text-2xl font-extrabold text-gray-900 mb-5">Vår historie</h2>
         <div className="prose prose-gray max-w-none text-gray-600 leading-relaxed space-y-4">
           <p>
-            Hire2Skill started with a simple observation: finding reliable help for everyday tasks was
-            surprisingly hard. Whether it was a leaky tap, a piece of furniture that needed assembling,
-            or a maths tutor for a struggling student — people were left searching through Facebook groups
-            and word-of-mouth recommendations, never quite sure who to trust.
+            Hire2Skill startet med en enkel observasjon: å finne pålitelig hjelp til dagligdagse oppgaver var
+            overraskende vanskelig. Enten det var en lekkende kran, et møbel som skulle monteres,
+            eller en mattelærer til en slitende elev — folk ble stående igjen med å søke gjennom Facebook-grupper
+            og jungeltelegrafen, aldri helt sikre på hvem de kunne stole på.
           </p>
           <p>
-            We built Hire2Skill to change that. Our platform makes it simple to post any task, browse
-            verified local helpers, read honest reviews, and book with confidence — all in a few minutes.
+            Vi bygde Hire2Skill for å endre på det. Vår plattform gjør det enkelt å legge ut ethvert oppdrag, bla gjennom
+            verifiserte lokale hjelpere, lese ærlige anmeldelser og bestille med trygghet — alt på få minutter.
           </p>
           <p>
-            Today, Hire2Skill operates across Norway, connecting thousands of people with skilled helpers
-            every week. We&apos;re proud that helpers on our platform earn fair rates for their expertise,
-            and that the people who use our service can get on with their lives knowing the job is in
-            good hands.
+            I dag opererer Hire2Skill over hele Norge, og kobler tusenvis av mennesker med dyktige hjelpere
+            hver uke. Vi er stolte av at hjelperne på vår plattform tjener rettferdige priser for sin ekspertise,
+            og at folk som bruker tjenesten vår kan komme videre med livene sine i visshet om at jobben er i
+            gode hender.
           </p>
         </div>
       </div>
@@ -107,7 +107,7 @@ export default function AboutPage() {
       {/* Values */}
       <div className="bg-gray-50 py-16">
         <div className="mx-auto max-w-4xl px-6">
-          <h2 className="text-2xl font-extrabold text-gray-900 mb-10 text-center">What we stand for</h2>
+          <h2 className="text-2xl font-extrabold text-gray-900 mb-10 text-center">Det vi står for</h2>
           <div className="grid sm:grid-cols-2 gap-6">
             {VALUES.map(v => (
               <div key={v.title} className="bg-white rounded-2xl border border-gray-200 p-6">
@@ -124,17 +124,17 @@ export default function AboutPage() {
 
       {/* CTA */}
       <div className="mx-auto max-w-3xl px-6 py-16 text-center">
-        <h2 className="text-2xl font-extrabold text-gray-900 mb-3">Ready to get started?</h2>
-        <p className="text-gray-500 mb-8">Post your first task free, or create a helper profile and start earning today.</p>
+        <h2 className="text-2xl font-extrabold text-gray-900 mb-3">Klar til å komme i gang?</h2>
+        <p className="text-gray-500 mb-8">Legg ut ditt første oppdrag gratis, eller opprett en hjelperprofil og begynn å tjene i dag.</p>
         <div className="flex flex-wrap justify-center gap-4">
           <Link href="/post"
             className="rounded-xl px-7 py-3 font-bold text-sm text-white"
             style={{ background: 'linear-gradient(135deg,#1E3A8A,#38BDF8)' }}>
-            Post a Task
+            Legg ut oppdrag
           </Link>
           <Link href="/signup"
             className="rounded-xl px-7 py-3 font-bold text-sm text-gray-700 border border-gray-200 hover:border-blue-300 transition-colors">
-            Become a Helper
+            Bli hjelper
           </Link>
         </div>
       </div>

--- a/src/app/contact/ContactForm.tsx
+++ b/src/app/contact/ContactForm.tsx
@@ -3,13 +3,13 @@
 import { useState } from 'react'
 
 const SUBJECTS = [
-  'General question',
-  'Booking issue',
-  'Payment or billing',
-  'Report a problem',
-  'Account access',
-  'Partnership enquiry',
-  'Other',
+  'Generelt spørsmål',
+  'Bookingproblem',
+  'Betaling eller fakturering',
+  'Rapporter et problem',
+  'Kontotilgang',
+  'Samarbeidsforespørsel',
+  'Annet',
 ]
 
 export default function ContactForm() {
@@ -42,11 +42,11 @@ export default function ContactForm() {
           style={{ background: 'linear-gradient(135deg,#1E3A8A,#38BDF8)' }}>
           ✓
         </div>
-        <h2 className="font-bold text-gray-900 text-xl">Message sent!</h2>
-        <p className="text-gray-500 text-sm">We&apos;ll get back to you at <strong>{form.email}</strong> within a few hours on business days.</p>
+        <h2 className="font-bold text-gray-900 text-xl">Melding sendt!</h2>
+        <p className="text-gray-500 text-sm">Vi kontakter deg på <strong>{form.email}</strong> innen noen timer på hverdager.</p>
         <button onClick={() => { setForm({ name: '', email: '', subject: SUBJECTS[0], message: '' }); setStatus('idle') }}
           className="text-sm text-blue-600 hover:underline mt-2">
-          Send another message
+          Send en ny melding
         </button>
       </div>
     )
@@ -54,17 +54,17 @@ export default function ContactForm() {
 
   return (
     <form onSubmit={submit} className="bg-white rounded-2xl border border-gray-200 p-6 flex flex-col gap-4">
-      <h2 className="font-bold text-gray-900 text-lg">Send us a message</h2>
+      <h2 className="font-bold text-gray-900 text-lg">Send oss en melding</h2>
 
       <div className="grid sm:grid-cols-2 gap-4">
         <div>
-          <label className="block text-xs font-semibold text-gray-600 mb-1">Your name</label>
+          <label className="block text-xs font-semibold text-gray-600 mb-1">Ditt navn</label>
           <input required value={form.name} onChange={e => set('name', e.target.value)}
             className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm text-gray-900 focus:outline-none focus:border-blue-400"
             placeholder="Kari Nordmann" />
         </div>
         <div>
-          <label className="block text-xs font-semibold text-gray-600 mb-1">Email address</label>
+          <label className="block text-xs font-semibold text-gray-600 mb-1">E-postadresse</label>
           <input required type="email" value={form.email} onChange={e => set('email', e.target.value)}
             className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm text-gray-900 focus:outline-none focus:border-blue-400"
             placeholder="kari@example.no" />
@@ -72,7 +72,7 @@ export default function ContactForm() {
       </div>
 
       <div>
-        <label className="block text-xs font-semibold text-gray-600 mb-1">Subject</label>
+        <label className="block text-xs font-semibold text-gray-600 mb-1">Emne</label>
         <select value={form.subject} onChange={e => set('subject', e.target.value)}
           className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm text-gray-900 focus:outline-none focus:border-blue-400 bg-white">
           {SUBJECTS.map(s => <option key={s}>{s}</option>)}
@@ -80,22 +80,22 @@ export default function ContactForm() {
       </div>
 
       <div>
-        <label className="block text-xs font-semibold text-gray-600 mb-1">Message</label>
+        <label className="block text-xs font-semibold text-gray-600 mb-1">Melding</label>
         <textarea required rows={5} value={form.message} onChange={e => set('message', e.target.value)}
           className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm text-gray-900 focus:outline-none focus:border-blue-400 resize-none"
-          placeholder="Describe your question or issue in as much detail as possible..." />
+          placeholder="Beskriv spørsmålet eller problemet ditt så detaljert som mulig..." />
       </div>
 
       {status === 'error' && (
         <p className="text-xs text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
-          Something went wrong. Please email us directly at support@hire2skill.com
+          Noe gikk galt. Vennligst send e-post direkte til support@hire2skill.com
         </p>
       )}
 
       <button type="submit" disabled={status === 'sending'}
         className="w-full rounded-xl py-3 font-bold text-sm text-white transition-opacity hover:opacity-90 disabled:opacity-60"
         style={{ background: 'linear-gradient(135deg,#1E3A8A,#38BDF8)' }}>
-        {status === 'sending' ? 'Sending…' : 'Send message'}
+        {status === 'sending' ? 'Sender…' : 'Send melding'}
       </button>
     </form>
   )

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,15 +1,15 @@
 import ContactForm from './ContactForm'
 
 export const metadata = {
-  title: 'Contact Us',
-  description: 'Get in touch with the Hire2Skill team. We\'re here to help with any questions about bookings, accounts, or your experience on the platform.',
+  title: 'Kontakt oss',
+  description: 'Ta kontakt med Hire2Skill-teamet. Vi er her for å hjelpe med spørsmål om bestillinger, kontoer eller din opplevelse på plattformen.',
 }
 
 const FAQ = [
-  { q: 'How do I cancel a booking?', a: 'Go to your Dashboard, find the booking, and click Cancel. Cancellation policies are set per-helper — check before booking.' },
-  { q: 'How do I report a problem with a helper?', a: 'Use the Contact form and select "Report a problem". Our trust & safety team responds within 24 hours.' },
-  { q: 'How do I reset my password?', a: 'On the login page, click "Forgot password" and we\'ll send a reset link to your email.' },
-  { q: 'When do I get paid as a helper?', a: 'Payments are released within 48 hours of a task being marked complete. Check your Account Balance in Settings.' },
+  { q: 'Hvordan avbestiller jeg en booking?', a: 'Gå til Dashboard, finn bookingen og klikk Avbestill. Avbestillingsregler settes per hjelper — sjekk før booking.' },
+  { q: 'Hvordan rapporterer jeg et problem med en hjelper?', a: 'Bruk kontaktskjemaet og velg "Rapporter et problem". Vårt trygghetsteam svarer innen 24 timer.' },
+  { q: 'Hvordan tilbakestiller jeg passordet mitt?', a: 'På innloggingssiden, klikk "Glemt passord" så sender vi en tilbakestillingslenke til e-posten din.' },
+  { q: 'Når får jeg utbetalt som hjelper?', a: 'Utbetalinger frigis innen 48 timer etter at et oppdrag er markert som fullført. Sjekk kontobalansen din i Innstillinger.' },
 ]
 
 export default function ContactPage() {
@@ -19,9 +19,9 @@ export default function ContactPage() {
       {/* Hero */}
       <div className="bg-white border-b border-gray-100">
         <div className="mx-auto max-w-4xl px-6 py-14">
-          <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 mb-3">Get in touch</h1>
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-gray-900 mb-3">Ta kontakt</h1>
           <p className="text-gray-500 text-lg max-w-xl">
-            We usually reply within a few hours on business days. For urgent help, include your booking ID.
+            Vi svarer vanligvis innen noen timer på hverdager. For akutt hjelp, inkluder booking-ID.
           </p>
         </div>
       </div>
@@ -36,27 +36,27 @@ export default function ContactPage() {
 
           {/* Contact details */}
           <div className="bg-white rounded-2xl border border-gray-200 p-6">
-            <h2 className="font-bold text-gray-900 mb-4">Other ways to reach us</h2>
+            <h2 className="font-bold text-gray-900 mb-4">Andre måter å nå oss på</h2>
             <div className="space-y-3">
               <div className="flex items-start gap-3">
                 <span className="text-xl">📧</span>
                 <div>
-                  <p className="text-sm font-semibold text-gray-700">Email</p>
+                  <p className="text-sm font-semibold text-gray-700">E-post</p>
                   <p className="text-sm text-gray-500">support@hire2skill.com</p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
                 <span className="text-xl">⏱️</span>
                 <div>
-                  <p className="text-sm font-semibold text-gray-700">Response time</p>
-                  <p className="text-sm text-gray-500">Mon–Fri, usually within 4 hours</p>
+                  <p className="text-sm font-semibold text-gray-700">Svartid</p>
+                  <p className="text-sm text-gray-500">Man–Fre, vanligvis innen 4 timer</p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
                 <span className="text-xl">📍</span>
                 <div>
-                  <p className="text-sm font-semibold text-gray-700">Registered address</p>
-                  <p className="text-sm text-gray-500">Hire2Skill AS, Oslo, Norway</p>
+                  <p className="text-sm font-semibold text-gray-700">Registrert adresse</p>
+                  <p className="text-sm text-gray-500">Hire2Skill AS, Oslo, Norge</p>
                 </div>
               </div>
             </div>
@@ -64,7 +64,7 @@ export default function ContactPage() {
 
           {/* Common questions */}
           <div>
-            <h2 className="font-bold text-gray-900 mb-4">Common questions</h2>
+            <h2 className="font-bold text-gray-900 mb-4">Vanlige spørsmål</h2>
             <div className="space-y-3">
               {FAQ.map(f => (
                 <div key={f.q} className="bg-white rounded-xl border border-gray-200 p-4">


### PR DESCRIPTION
## Summary
- **What problem does this PR solve?**
  - The `/app/about` and `/app/contact` pages were displaying in English while the rest of the site defaults to Norwegian, creating an inconsistent user experience for Norwegian visitors.

- **What changed and why?**
  - Replaced all hardcoded English text with Norwegian translations in:
    - `src/app/about/page.tsx` - Hero section, stats, values, story, and CTA
    - `src/app/contact/page.tsx` - Hero, FAQ, contact information
    - `src/app/contact/ContactForm.tsx` - Form labels, subjects, messages, buttons
  - This ensures these static pages match the Norwegian default language of the rest of the site

## Checklist
- [ ] Lint passes (`npm run lint`)
- [ ] Typecheck passes (`npm run typecheck`)
- [ ] Build passes (`npm run build`)
- [ ] E2E smoke passes (`npm run test:e2e`)
- [x] Migration reviewed (if DB schema changed) - N/A, no DB changes
- [x] API/auth changes reviewed for security impact - N/A, no API/auth changes
- [x] i18n copy updated for EN + NO where relevant - Direct Norwegian text replacement (not using translation system)
- [x] Accessibility checks done for new UI controls - N/A, no new controls, only text changes

## Test plan
- [ ] Happy path tested locally
  - Navigate to `/about` and verify all text displays in Norwegian
  - Navigate to `/contact` and verify all text displays in Norwegian
  - Submit contact form and verify success/error messages are in Norwegian
- [ ] Error path tested locally
  - Test contact form validation messages
  - Test contact form submission error state
- [ ] Mobile view checked (if UI touched)
  - Verify text wrapping and layout on mobile devices

## Risk and rollback
- **Risk level:** low
- **Rollback steps:**
  - Revert commit(s)
  - Re-run CI
  - No migration applied, no additional steps needed